### PR TITLE
Fixed Water.mo Modelica errors

### DIFF
--- a/ThermoPower/Water.mo
+++ b/ThermoPower/Water.mo
@@ -2180,9 +2180,8 @@ enthalpy between the nodes; this requires the availability of the time derivativ
     "1-dimensional fluid flow model for water/steam (finite elements)"
     extends BaseClasses.Flow1DBase(
       Nw = N,
-      redeclare replaceable package Medium = StandardWater
-        constrainedby Modelica.Media.Interfaces.PartialTwoPhaseMedium
-        "Medium model");
+      redeclare replaceable package Medium = StandardWater "Medium model"
+        constrainedby Modelica.Media.Interfaces.PartialTwoPhaseMedium);
       replaceable model HeatTransfer =
         Thermal.HeatTransferFEM.IdealHeatTransfer
       constrainedby ThermoPower.Thermal.BaseClasses.DistributedHeatTransferFEM
@@ -6132,8 +6131,8 @@ This model is not yet complete
     "1-dimensional fluid flow model for water/steam (finite volumes, 2-phase)"
     extends Modelica.Icons.ObsoleteModel;
     extends BaseClasses.Flow1DBase(redeclare replaceable package Medium =
-          StandardWater constrainedby
-        Modelica.Media.Interfaces.PartialTwoPhaseMedium "Medium model",
+          StandardWater "Medium model" constrainedby
+        Modelica.Media.Interfaces.PartialTwoPhaseMedium,
         FluidPhaseStart=Choices.FluidPhase.FluidPhases.TwoPhases);
     replaceable ThermoPower.Thermal.DHT wall(N=N) annotation (Dialog(enable=
             false), Placement(transformation(extent={{-40,40},{40,60}},
@@ -7342,8 +7341,8 @@ enthalpy between the nodes; this requires the availability of the time derivativ
     import ThermoPower.Choices.Flow1D.FFtypes;
     import ThermoPower.Choices.Flow1D.HCtypes;
     extends BaseClasses.Flow1DBase(redeclare replaceable package Medium =
-          StandardWater constrainedby
-        Modelica.Media.Interfaces.PartialTwoPhaseMedium "Medium model");
+          StandardWater "Medium model" constrainedby
+        Modelica.Media.Interfaces.PartialTwoPhaseMedium);
     replaceable ThermoPower.Thermal.DHT wall(N=N) annotation (Dialog(enable=
             false), Placement(transformation(extent={{-40,40},{40,60}},
             rotation=0)));


### PR DESCRIPTION
Fixing three additional occurrences of "Medium model" string-comment appearing after 'constrainedby'. 
The string-comment, "Medium model", is not allowed by the Modelica syntax where it appears there. It must come before the 'constrainedby' keyword.
