### PR TITLE
Flow1DFV2w fix

### DIFF
--- a/ThermoPower/Gas.mo
+++ b/ThermoPower/Gas.mo
@@ -1260,7 +1260,7 @@ package Gas "Models of components with ideal gases as working fluid"
     replaceable model HeatTransfer2 = Thermal.HeatTransferFV.IdealHeatTransfer
       constrainedby ThermoPower.Thermal.BaseClasses.DistributedHeatTransferFV
       annotation (choicesAllMatching=true);
-    HeatTransfer heatTransfer2(
+    HeatTransfer2 heatTransfer2(
       redeclare package Medium = Medium,
       final Nf=N,
       final Nw=Nw,


### PR DESCRIPTION
This change is needed so that the selection for the HeatTransfer2 model is reflected in wall2 thermal behavior. Currently, the selection for HeatTransfer2 is not utilized.