### PR TITLE
Fix invalid position of description string in redeclare/constrainedby.

### DIFF
--- a/ThermoPower/Water.mo
+++ b/ThermoPower/Water.mo
@@ -1468,9 +1468,8 @@ outlet is ignored; use <t>Pump</t> models if this has to be taken into account c
   model Flow1DFV2ph
     "1-dimensional fluid flow model for water/steam (finite volumes, 2-phase)"
     extends BaseClasses.Flow1DBase(redeclare replaceable package Medium =
-          StandardWater                constrainedby
-        Modelica.Media.Interfaces.PartialTwoPhaseMedium
-                        "Medium model",
+          StandardWater "Medium model" constrainedby
+        Modelica.Media.Interfaces.PartialTwoPhaseMedium,
         FluidPhaseStart=Choices.FluidPhase.FluidPhases.TwoPhases);
     replaceable model HeatTransfer = Thermal.HeatTransferFV.IdealHeatTransfer
       constrainedby ThermoPower.Thermal.BaseClasses.DistributedHeatTransferFV
@@ -2354,9 +2353,8 @@ enthalpy between the nodes; this requires the availability of the time derivativ
     "1-dimensional fluid flow model for water/steam (finite elements)"
     extends BaseClasses.Flow1DBase(
       Nw = N,
-      redeclare replaceable package Medium = StandardWater
-        constrainedby Modelica.Media.Interfaces.PartialTwoPhaseMedium
-                                                           "Medium model");
+      redeclare replaceable package Medium = StandardWater "Medium model"
+        constrainedby Modelica.Media.Interfaces.PartialTwoPhaseMedium);
       replaceable model HeatTransfer =
         Thermal.HeatTransferFEM.IdealHeatTransfer
       constrainedby ThermoPower.Thermal.BaseClasses.DistributedHeatTransferFEM
@@ -6716,9 +6714,8 @@ This model is not yet complete
     "1-dimensional fluid flow model for water/steam (finite volumes, 2-phase)"
     extends Modelica.Icons.ObsoleteModel;
     extends BaseClasses.Flow1DBase(redeclare replaceable package Medium =
-          StandardWater                constrainedby
-        Modelica.Media.Interfaces.PartialTwoPhaseMedium
-                        "Medium model",
+          StandardWater "Medium model" constrainedby
+        Modelica.Media.Interfaces.PartialTwoPhaseMedium,
         FluidPhaseStart=Choices.FluidPhase.FluidPhases.TwoPhases);
     replaceable ThermoPower.Thermal.DHT wall(N=N) annotation (Dialog(enable=
             false), Placement(transformation(extent={{-40,40},{40,60}},
@@ -7927,9 +7924,8 @@ enthalpy between the nodes; this requires the availability of the time derivativ
     import ThermoPower.Choices.Flow1D.FFtypes;
     import ThermoPower.Choices.Flow1D.HCtypes;
     extends BaseClasses.Flow1DBase(redeclare replaceable package Medium =
-          StandardWater                constrainedby
-        Modelica.Media.Interfaces.PartialTwoPhaseMedium
-                        "Medium model");
+          StandardWater "Medium model" constrainedby
+        Modelica.Media.Interfaces.PartialTwoPhaseMedium);
     replaceable ThermoPower.Thermal.DHT wall(N=N) annotation (Dialog(enable=
             false), Placement(transformation(extent={{-40,40},{40,60}},
             rotation=0)));


### PR DESCRIPTION
This pull request fixes invalid Modelica syntax. The previous positions of the description strings `"Medium model"` are not possible according to the Modelica grammar in the specification.